### PR TITLE
ci: add smoke tests for baseline upstream OTel behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2.1
+
+filters_always: &filters_always
+  filters:
+    tags:
+      only: /.*/
+
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
+orbs:
+  bats: circleci/bats@1.0.0
+
+jobs:
+  smoke_test:
+    machine:
+      image: ubuntu-2004:2023.04.2
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - bats/install
+      - run:
+          name: What's the BATS?
+          command: |
+            which bats
+            bats --version
+      - run:
+          name: Smoke Test
+          command: make smoke
+      - store_test_results:
+          path: ./smoke-tests/
+      - store_artifacts:
+          path: ./smoke-tests/report.xml
+      - store_artifacts:
+          path: ./smoke-tests/collector/data-results
+      - run:
+          name: Extinguish the flames
+          command: make unsmoke
+
+workflows:
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - smoke_test
+
+  build:
+    jobs:
+      - smoke_test:
+          <<: *filters_always
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ orbs:
 jobs:
   smoke_test:
     machine:
-      image: ubuntu-2004:2023.04.2
+      image: ubuntu-2204:2024.01.1
     steps:
       - checkout
       - attach_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+smoke-tests/collector/data.json
+smoke-tests/collector/data-results/data*
+smoke-tests/report.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.circleci/process.yml
 smoke-tests/collector/data.json
 smoke-tests/collector/data-results/data*
 smoke-tests/report.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# A Makefile? For a Ruby project?!? What about a Rakefile?
+# Yes, a Makefile. We've standardized on Makefiles as a portable way to automate tasks
+# across our polyglot projects.
+
+# set shell to bash to make shell builtin behaviour consistent
+SHELL := /usr/bin/env bash
+
+#: clean up the dev environment
+clean: clean-smoke-tests
+
+#: run the smoke tests
+smoke: smoke-app
+
+#: cleanup the smoke and smoke it again
+resmoke: unsmoke smoke
+
+#: run the smoke test for a simple, instrumented Ruby script
+smoke-app: smoke-tests/collector/data.json
+	@echo ""
+	@echo "+++ Running example app smoke tests."
+	@echo ""
+	cd smoke-tests && bats ./smoke-example-app.bats --report-formatter junit --output ./
+
+#: clear data from smoke tests
+smoke-tests/collector/data.json:
+	@echo ""
+	@echo "+++ Zhuzhing smoke test's Collector data.json"
+	@touch $@ && chmod o+w $@
+
+#: cleans up smoke test output
+clean-smoke-tests:
+	rm -rf ./smoke-tests/collector/data.json
+	rm -rf ./smoke-tests/collector/data-results/*.json
+	rm -rf ./smoke-tests/report.*
+
+#: tear down the smoke test environment
+unsmoke:
+	@echo ""
+	@echo "+++ Spinning down the smokers."
+	@echo ""
+	cd smoke-tests && docker-compose down --volumes

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SHELL := /usr/bin/env bash
 clean: clean-smoke-tests
 
 #: run the smoke tests
-smoke: smoke-app
+smoke: smoke-app smoke-sinatra
 
 #: cleanup the smoke and smoke it again
 resmoke: unsmoke smoke
@@ -20,6 +20,13 @@ smoke-app: smoke-tests/collector/data.json
 	@echo "+++ Running example app smoke tests."
 	@echo ""
 	cd smoke-tests && bats ./smoke-example-app.bats --report-formatter junit --output ./
+
+#: run the smoke test for a simple, instrumented Ruby script
+smoke-sinatra: smoke-tests/collector/data.json
+	@echo ""
+	@echo "+++ Running example sinatra smoke tests."
+	@echo ""
+	cd smoke-tests && bats ./smoke-example-app-sinatra.bats --report-formatter junit --output ./
 
 #: clear data from smoke tests
 smoke-tests/collector/data.json:

--- a/examples/hello-world/Dockerfile
+++ b/examples/hello-world/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.0
+
+WORKDIR /app
+
+RUN gem install bundler
+
+# Copy the examples into the image and install deps.
+COPY examples/ ./examples/
+RUN cd ./examples/hello-world && bundle install
+
+# From this point forward, we're operating on the example app.
+WORKDIR /app/examples/hello-world
+CMD ["ruby", "app.rb"]

--- a/examples/hello-world/Gemfile
+++ b/examples/hello-world/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "opentelemetry-sdk"
+gem "opentelemetry-exporter-otlp"

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,22 @@
+# hello-world
+
+This simple Ruby app returns "Hello World".
+It is a minimal app instrumented directly with the OpenTelemetry Ruby SDK.
+
+## Prerequisites
+
+You'll also need ...
+
+## Running the example
+
+Install the dependencies:
+
+```bash
+bundle install
+```
+
+Run the application with an exporter configured to display traces on stdout:
+
+```bash
+OTEL_TRACES_EXPORTER=console ruby ./app.rb
+```

--- a/examples/hello-world/app.rb
+++ b/examples/hello-world/app.rb
@@ -1,0 +1,29 @@
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+
+OpenTelemetry::SDK.configure do |c|
+  unless ENV['OTEL_SERVICE_NAME']
+    c.service_name = 'otel-ruby-example'
+  end
+end
+
+# for this simple command-and-exit example, we can safely set an at_exit() hook
+# to ensure that spans are flushed through the exporter before the process exits
+at_exit { OpenTelemetry.tracer_provider.shutdown(timeout: 5) }
+
+# We'll need a tracer for our custom instrumentation
+Tracer = OpenTelemetry.tracer_provider.tracer('hello_world_tracer', '0.1.0')
+
+def hello_world
+  "Hello, World!"
+    .tap do |message|
+      Tracer.in_span('hello') do |span|
+        Tracer.in_span('world') do |span|
+          span.set_attribute("message", message)
+          puts(message)
+        end
+      end
+    end
+end
+
+hello_world

--- a/examples/sinatra/Dockerfile
+++ b/examples/sinatra/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:3.0
+
+WORKDIR /app
+
+RUN gem install bundler
+
+# Copy the examples into the image and install deps.
+RUN mkdir examples
+COPY examples/sinatra/ ./examples/sinatra/
+RUN cd ./examples/sinatra && bundle install
+
+# From this point forward, we're operating on the example app.
+WORKDIR /app/examples/sinatra
+CMD ["ruby", "app.rb"]

--- a/examples/sinatra/Gemfile
+++ b/examples/sinatra/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rackup"
+gem "sinatra"
+gem "opentelemetry-sdk"
+gem "opentelemetry-exporter-otlp"
+gem "opentelemetry-instrumentation-sinatra"

--- a/examples/sinatra/README.md
+++ b/examples/sinatra/README.md
@@ -1,0 +1,22 @@
+# Sinatra
+
+This simple Ruby Sinatra app that returns "Hello World".
+It is a minimal web app instrumented directly with the OpenTelemetry Ruby SDK and with OpenTelemetry libraries for Rack and Sinatra.
+
+## Prerequisites
+
+You'll also need ...
+
+## Running the example
+
+Install the dependencies:
+
+```bash
+bundle install
+```
+
+Run the application with an exporter configured to display traces on stdout:
+
+```bash
+OTEL_TRACES_EXPORTER=console ruby ./app.rb
+```

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -1,0 +1,37 @@
+require 'sinatra'
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+require 'opentelemetry/instrumentation/sinatra'
+
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = 'otel-ruby-example' unless ENV['OTEL_SERVICE_NAME']
+  c.use_all()
+end
+at_exit { OpenTelemetry.tracer_provider.shutdown(timeout: 5) }
+
+class AnApp < Sinatra::Base
+  configure do
+    set :bind, '0.0.0.0' # for use in docker
+  end
+
+  # We'll need a tracer for our custom instrumentation
+  Tracer = OpenTelemetry.tracer_provider.tracer('sinatra_tracer', '0.1.0')
+
+  get '/' do
+    OpenTelemetry::Trace
+      .current_span
+      .set_attribute("custom_field", "important value")
+
+      "Hello, World!"
+        .tap do |message|
+          Tracer.in_span('hello') do |span|
+            Tracer.in_span('world') do |span|
+              span.set_attribute("message", message)
+              puts(message)
+            end
+          end
+        end
+  end
+end
+
+AnApp.run!

--- a/smoke-tests/collector/otel-collector-config.yaml
+++ b/smoke-tests/collector/otel-collector-config.yaml
@@ -1,0 +1,21 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  file:
+    path: /var/lib/data.json
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [file, debug]

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.0'
+
+x-env-base:
+  &env_base
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://collector:4318
+  OTEL_SERVICE_NAME: "otel-ruby-example"
+  OTEL_EXPORTER_OTLP_INSECURE: "true"
+
+services:
+  collector:
+    image: otel/opentelemetry-collector:0.97.0
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - "./collector/otel-collector-config.yaml:/etc/otel-collector-config.yaml"
+      - "./collector:/var/lib"
+
+  app:
+    build:
+      context: ../
+      dockerfile: ./examples/hello-world/Dockerfile
+    image: honeycomb/hello-world
+    depends_on:
+      - collector
+    environment:
+      <<: *env_base
+

--- a/smoke-tests/docker-compose.yml
+++ b/smoke-tests/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3.0'
 x-env-base:
   &env_base
   OTEL_EXPORTER_OTLP_ENDPOINT: http://collector:4318
-  OTEL_SERVICE_NAME: "otel-ruby-example"
   OTEL_EXPORTER_OTLP_INSECURE: "true"
 
 services:
@@ -23,4 +22,18 @@ services:
       - collector
     environment:
       <<: *env_base
+      OTEL_SERVICE_NAME: "otel-ruby-example"
+
+  app-sinatra:
+    build:
+      context: ../
+      dockerfile: ./examples/sinatra/Dockerfile
+    image: honeycomb/sinatra
+    ports:
+      - "4567:4567"
+    depends_on:
+      - collector
+    environment:
+      <<: *env_base
+      OTEL_SERVICE_NAME: "otel-sinatra-example"
 

--- a/smoke-tests/smoke-example-app-sinatra.bats
+++ b/smoke-tests/smoke-example-app-sinatra.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+load test_helpers/utilities
+
+CONTAINER_NAME="app-sinatra"
+COLLECTOR_NAME="collector"
+OTEL_SERVICE_NAME="otel-sinatra-example"
+TRACER_NAME="sinatra_tracer"
+
+setup_file() {
+	docker-compose up --build --detach collector ${CONTAINER_NAME}
+	wait_for_ready_app ${CONTAINER_NAME}
+	curl --silent localhost:4567
+	wait_for_traces
+}
+
+teardown_file() {
+ 	cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
+	docker-compose stop ${CONTAINER_NAME}
+	docker-compose restart collector # clears/flushes the Collector output file
+	wait_for_flush
+}
+
+# TESTS
+
+@test "Auto instrumentation produces a Rack span" {
+  result=$(span_names_for "OpenTelemetry::Instrumentation::Rack")
+  assert_equal "$result" '"GET /"'
+}
+
+@test "Manual instrumentation adds custom attribute" {
+	result=$(span_attributes_for "OpenTelemetry::Instrumentation::Rack" | jq "select(.key == \"custom_field\").value.stringValue")
+	assert_equal "$result" '"important value"'
+}
+
+@test "Manual instrumentation produces parent and child spans with names of spans" {
+	result=$(span_names_for ${TRACER_NAME})
+	assert_equal "$result" '"world"
+"hello"'
+}

--- a/smoke-tests/smoke-example-app.bats
+++ b/smoke-tests/smoke-example-app.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+load test_helpers/utilities
+
+CONTAINER_NAME="app"
+COLLECTOR_NAME="collector"
+OTEL_SERVICE_NAME="otel-ruby-example"
+TRACER_NAME="hello_world_tracer"
+
+setup_file() {
+	echo "# 🚧" >&3
+	docker-compose up --build --detach collector
+	wait_for_ready_collector ${COLLECTOR_NAME}
+	docker-compose up --build --detach ${CONTAINER_NAME}
+	wait_for_traces
+}
+
+teardown_file() {
+	cp collector/data.json collector/data-results/data-${CONTAINER_NAME}.json
+	docker-compose stop ${CONTAINER_NAME}
+	docker-compose restart collector
+	wait_for_flush
+}
+
+# TESTS
+
+@test "Manual instrumentation produces parent and child spans with names of spans" {
+	result=$(span_names_for ${TRACER_NAME})
+	assert_equal "$result" '"world"
+"hello"'
+}
+
+@test "Manual instrumentation adds custom attribute" {
+	result=$(span_attributes_for "${TRACER_NAME}" | jq "select(.key == \"message\").value.stringValue")
+	assert_equal "$result" '"Hello, World!"'
+}

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -90,7 +90,7 @@ wait_for_ready_app() {
 	MAX_RETRIES=10
 	echo -n "# 🍿 Setting up ${CONTAINER}" >&3
 	NEXT_WAIT_TIME=0
-	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [[ $(docker-compose logs ${CONTAINER} | grep "Running on http:") ]]
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [[ $(docker-compose logs ${CONTAINER} | grep "taken the stage on 4567") ]]
 	do
 		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
 		sleep $NEXT_WAIT_TIME

--- a/smoke-tests/test_helpers/utilities.bash
+++ b/smoke-tests/test_helpers/utilities.bash
@@ -1,0 +1,118 @@
+# UTILITY FUNCS
+
+spans_from_library_named() {
+	spans_received | jq ".scopeSpans[] | select(.scope.name == \"$1\").spans[]"
+}
+
+spans_received() {
+	jq ".resourceSpans[]?" ./collector/data.json
+}
+
+# test span name
+span_names_for() {
+	spans_from_library_named $1 | jq '.name'
+}
+
+# test span attributes
+span_attributes_for() {
+	# $1 - library name
+
+	spans_from_library_named $1 | \
+		jq ".attributes[]"
+}
+
+# Arguments
+# $1 - retry limit (default 5); Nth retry sleeps for N seconds
+wait_for_data() {
+	echo -n "# ⏳ Waiting for collector to receive data" >&3
+	NEXT_WAIT_TIME=0
+	MAX_RETRIES=${1:-5}
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [ "$(wc -l ./collector/data.json | awk '{ print $1 }')" -ne 0 ]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt $MAX_RETRIES ]
+}
+
+# Arguments
+# $1 - retry limit (default 5); Nth retry sleeps for N seconds
+wait_for_traces() {
+	echo -n "# ⏳ Waiting for collector to receive traces" >&3
+	NEXT_WAIT_TIME=0
+	MAX_RETRIES=${1:-5}
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [ "$(spans_received)" != "" ]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt $MAX_RETRIES ]
+}
+
+wait_for_flush() {
+	echo -n "# ⏳ Waiting for collector data flush" >&3
+	NEXT_WAIT_TIME=0
+	until [ $NEXT_WAIT_TIME -eq 5 ] || [ "$(wc -l ./collector/data.json | awk '{ print $1 }')" -eq 0 ]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt 5 ]
+}
+
+# Wait loop for our collector to be started and ready to receive traffic.
+#
+# Arguments:
+#   $1 - the name of the container/service in which the app is running
+wait_for_ready_collector() {
+	COLLECTOR=${1:?collector name is a required parameter}
+	MAX_RETRIES=10
+	echo -n "# 🍿 Setting up ${COLLECTOR}" >&3
+	NEXT_WAIT_TIME=0
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [[ $(docker-compose logs ${COLLECTOR} | grep "Everything is ready. Begin running and processing data.") ]]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt $MAX_RETRIES ]
+}
+
+# Wait loop for one of our example apps to be started and ready to receive traffic.
+#
+# Arguments:
+#   $1 - the name of the container/service in which the app is running
+wait_for_ready_app() {
+	CONTAINER=${1:?container name is a required parameter}
+	MAX_RETRIES=10
+	echo -n "# 🍿 Setting up ${CONTAINER}" >&3
+	NEXT_WAIT_TIME=0
+	until [ $NEXT_WAIT_TIME -eq $MAX_RETRIES ] || [[ $(docker-compose logs ${CONTAINER} | grep "Running on http:") ]]
+	do
+		echo -n " ... $(( NEXT_WAIT_TIME++ ))s" >&3
+		sleep $NEXT_WAIT_TIME
+	done
+	echo "" >&3
+	[ $NEXT_WAIT_TIME -lt $MAX_RETRIES ]
+}
+
+# Fail and display details if the expected and actual values do not
+# equal. Details include both values.
+#
+# Lifted and then drastically simplified from bats-assert * bats-support
+assert_equal() {
+	if [[ $1 != "$2" ]]; then
+		{
+			echo
+			echo "-- 💥 values are not equal 💥 --"
+			echo "expected : $2"
+			echo "actual   : $1"
+			echo "--"
+			echo
+		} >&2 # output error to STDERR
+		return 1
+	fi
+}


### PR DESCRIPTION
Establish our usual distro smoke tests, but only for stock, upstream OTel behavior. As we reimplement the distro components standalone in Ruby, these will let us assert that we did it right.
