### PR TITLE
ci: reference new name for our OSS mgmt repo

### DIFF
--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Apply common project labels
     steps:
-      - uses: honeycombio/oss-management-actions/labels@v1
+      - uses: honeycombio/oss-management/labels@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Which problem is this PR solving?

My changes to the content created by the repo template yesterday broke one of the workflows. Oops.