### PR TITLE
ci: add lint/format/style checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,14 @@ jobs:
       - ruby/install-deps
       - run: make test
 
+  style:
+    docker:
+      - image: cimg/ruby:2.7
+    steps:
+      - checkout
+      - ruby/install-deps
+      - run: make style
+
   smoke_test:
     machine:
       image: ubuntu-2204:2024.01.1
@@ -65,6 +73,8 @@ workflows:
 
   build:
     jobs:
+      - style:
+          <<: *filters_always
       - test:
           <<: *filters_always
       - smoke_test:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,5 +2,9 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: "3.0"
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: "3.0"
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: "3.0"
+  TargetRubyVersion: "2.7"
 
 Metrics/BlockLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 # Development dependencies declared here.
+gem "opentelemetry-sdk", ">= 1.0.0"
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
 gem "rubocop"
-gem "opentelemetry-sdk", ">= 1.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gemspec
 # Development dependencies declared here.
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
+gem "rubocop"
 gem "opentelemetry-sdk", ">= 1.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 # Runtime dependencies are declared honeycomb-opentelemetry.gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     diff-lcs (1.5.1)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
     opentelemetry-api (1.1.0)
     opentelemetry-common (0.19.7)
       opentelemetry-api (~> 1.0)
@@ -20,7 +23,15 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.0)
       opentelemetry-api (~> 1.0)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
+    rainbow (3.1.1)
     rake (12.3.3)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -34,6 +45,21 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
+    rubocop (1.63.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.2)
+      parser (>= 3.3.0.4)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby
@@ -43,6 +69,7 @@ DEPENDENCIES
   opentelemetry-sdk (>= 1.0.0)
   rake (~> 12.0)
   rspec (~> 3.0)
+  rubocop
 
 BUNDLED WITH
    2.1.4

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ test:
 	@echo "+++ Running tests"
 	bundle exec rake spec
 
+#: run the lint checks
+lint:
+	@echo "+++ Running the linter"
+	bundle exec rubocop --lint
+
 #: run all the lint/format/style checks
 style: rubocop
 rubocop:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ lint:
 	@echo "+++ Running the linter"
 	bundle exec rubocop --lint
 
+#: fix code layout/formatting issues
+fix-layout:
+	@echo "+++ Fixing code layout"
+	bundle exec rubocop --fix-layout
+
 #: run all the lint/format/style checks
 style: rubocop
 rubocop:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ test:
 	@echo "+++ Running tests"
 	bundle exec rake spec
 
+#: run all the lint/format/style checks
+style: rubocop
+rubocop:
+	@echo "+++ Running all style checks"
+	bundle exec rubocop
+
 #: clean up the dev environment
 clean: clean-smoke-tests
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/examples/hello-world/Gemfile
+++ b/examples/hello-world/Gemfile
@@ -2,5 +2,5 @@
 
 source "https://rubygems.org"
 
-gem "opentelemetry-sdk"
 gem "opentelemetry-exporter-otlp"
+gem "opentelemetry-sdk"

--- a/examples/hello-world/app.rb
+++ b/examples/hello-world/app.rb
@@ -17,9 +17,9 @@ Tracer = OpenTelemetry.tracer_provider.tracer('hello_world_tracer', '0.1.0')
 def hello_world
   "Hello, World!"
     .tap do |message|
-      Tracer.in_span('hello') do |span|
-        Tracer.in_span('world') do |span|
-          span.set_attribute("message", message)
+      Tracer.in_span('hello') do |_hello_span|
+        Tracer.in_span('world') do |world_span|
+          world_span.set_attribute("message", message)
           puts(message)
         end
       end

--- a/examples/hello-world/app.rb
+++ b/examples/hello-world/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "opentelemetry/sdk"
 require "opentelemetry/exporter/otlp"
 

--- a/examples/hello-world/app.rb
+++ b/examples/hello-world/app.rb
@@ -1,9 +1,9 @@
-require 'opentelemetry/sdk'
-require 'opentelemetry/exporter/otlp'
+require "opentelemetry/sdk"
+require "opentelemetry/exporter/otlp"
 
 OpenTelemetry::SDK.configure do |c|
-  unless ENV['OTEL_SERVICE_NAME']
-    c.service_name = 'otel-ruby-example'
+  unless ENV["OTEL_SERVICE_NAME"]
+    c.service_name = "otel-ruby-example"
   end
 end
 
@@ -12,13 +12,13 @@ end
 at_exit { OpenTelemetry.tracer_provider.shutdown(timeout: 5) }
 
 # We'll need a tracer for our custom instrumentation
-Tracer = OpenTelemetry.tracer_provider.tracer('hello_world_tracer', '0.1.0')
+Tracer = OpenTelemetry.tracer_provider.tracer("hello_world_tracer", "0.1.0")
 
 def hello_world
   "Hello, World!"
     .tap do |message|
-      Tracer.in_span('hello') do |_hello_span|
-        Tracer.in_span('world') do |world_span|
+      Tracer.in_span("hello") do |_hello_span|
+        Tracer.in_span("world") do |world_span|
           world_span.set_attribute("message", message)
           puts(message)
         end

--- a/examples/hello-world/app.rb
+++ b/examples/hello-world/app.rb
@@ -4,9 +4,7 @@ require "opentelemetry/sdk"
 require "opentelemetry/exporter/otlp"
 
 OpenTelemetry::SDK.configure do |c|
-  unless ENV["OTEL_SERVICE_NAME"]
-    c.service_name = "otel-ruby-example"
-  end
+  c.service_name = "otel-ruby-example" unless ENV["OTEL_SERVICE_NAME"]
 end
 
 # for this simple command-and-exit example, we can safely set an at_exit() hook

--- a/examples/sinatra/Gemfile
+++ b/examples/sinatra/Gemfile
@@ -2,9 +2,9 @@
 
 source "https://rubygems.org"
 
-gem "rackup"
-gem "sinatra"
-gem "opentelemetry-sdk"
+gem "honeycomb-opentelemetry", path: "../.."
 gem "opentelemetry-exporter-otlp"
 gem "opentelemetry-instrumentation-sinatra"
-gem "honeycomb-opentelemetry", path: "../.."
+gem "opentelemetry-sdk"
+gem "rackup"
+gem "sinatra"

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -26,6 +26,7 @@ OpenTelemetry::SDK.configure do |c|
 end
 at_exit { OpenTelemetry.tracer_provider.shutdown(timeout: 5) }
 
+# a minimally instrumented Sinatra app
 class AnApp < Sinatra::Base
   configure do
     set :bind, "0.0.0.0" # for use in docker

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "sinatra"
 require "opentelemetry/sdk"
 require "opentelemetry/exporter/otlp"

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -1,11 +1,11 @@
-require 'sinatra'
-require 'opentelemetry/sdk'
-require 'opentelemetry/exporter/otlp'
-require 'opentelemetry/instrumentation/sinatra'
-require 'honeycomb/opentelemetry'
+require "sinatra"
+require "opentelemetry/sdk"
+require "opentelemetry/exporter/otlp"
+require "opentelemetry/instrumentation/sinatra"
+require "honeycomb/opentelemetry"
 
 OpenTelemetry::SDK.configure do |c|
-  c.service_name = 'otel-ruby-example' unless ENV['OTEL_SERVICE_NAME']
+  c.service_name = "otel-ruby-example" unless ENV["OTEL_SERVICE_NAME"]
   c.use_all()
 
   # Add the BaggageSpanProcessor to the collection of span processors
@@ -26,13 +26,13 @@ at_exit { OpenTelemetry.tracer_provider.shutdown(timeout: 5) }
 
 class AnApp < Sinatra::Base
   configure do
-    set :bind, '0.0.0.0' # for use in docker
+    set :bind, "0.0.0.0" # for use in docker
   end
 
   # We'll need a tracer for our custom instrumentation
-  Tracer = OpenTelemetry.tracer_provider.tracer('sinatra_tracer', '0.1.0')
+  Tracer = OpenTelemetry.tracer_provider.tracer("sinatra_tracer", "0.1.0")
 
-  get '/' do
+  get "/" do
     OpenTelemetry::Trace
       .current_span
       .set_attribute("custom_field", "important value")
@@ -42,8 +42,8 @@ class AnApp < Sinatra::Base
     OpenTelemetry::Context.with_current(context_for_the_children) do
       "Hello, World!"
         .tap do |message|
-          Tracer.in_span('hello') do |_hello_span|
-            Tracer.in_span('world') do |world_span|
+          Tracer.in_span("hello") do |_hello_span|
+            Tracer.in_span("world") do |world_span|
               world_span.set_attribute("message", message)
               puts(message)
             end

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -8,7 +8,7 @@ require "honeycomb/opentelemetry"
 
 OpenTelemetry::SDK.configure do |c|
   c.service_name = "otel-ruby-example" unless ENV["OTEL_SERVICE_NAME"]
-  c.use_all()
+  c.use_all
 
   # Add the BaggageSpanProcessor to the collection of span processors
   c.add_span_processor(Honeycomb::OpenTelemetry::Trace::BaggageSpanProcessor.new)
@@ -20,7 +20,7 @@ OpenTelemetry::SDK.configure do |c|
   c.add_span_processor(
     # these constructors without arguments will pull config from the environment
     OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-      OpenTelemetry::Exporter::OTLP::Exporter.new()
+      OpenTelemetry::Exporter::OTLP::Exporter.new
     )
   )
 end

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -42,9 +42,9 @@ class AnApp < Sinatra::Base
     OpenTelemetry::Context.with_current(context_for_the_children) do
       "Hello, World!"
         .tap do |message|
-          Tracer.in_span('hello') do |span|
-            Tracer.in_span('world') do |span|
-              span.set_attribute("message", message)
+          Tracer.in_span('hello') do |_hello_span|
+            Tracer.in_span('world') do |world_span|
+              world_span.set_attribute("message", message)
               puts(message)
             end
           end

--- a/honeycomb-opentelemetry.gemspec
+++ b/honeycomb-opentelemetry.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"

--- a/honeycomb-opentelemetry.gemspec
+++ b/honeycomb-opentelemetry.gemspec
@@ -1,4 +1,4 @@
-require_relative 'lib/honeycomb/opentelemetry/version'
+require_relative "lib/honeycomb/opentelemetry/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "honeycomb-opentelemetry"
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"

--- a/honeycomb-opentelemetry.gemspec
+++ b/honeycomb-opentelemetry.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Honeycomb's OpenTelemetry Ruby extras"
   spec.homepage      = "https://github.com/honeycombio/honeycomb-opentelemetry-ruby"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/honeycombio/honeycomb-opentelemetry-ruby"

--- a/honeycomb-opentelemetry.gemspec
+++ b/honeycomb-opentelemetry.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/honeycombio/honeycomb-opentelemetry-ruby"
   spec.metadata["bug_tracker_uri"] = "https://github.com/honeycombio/honeycomb-opentelemetry-ruby/issues"
   spec.metadata["changelog_uri"] = "https://github.com/honeycombio/honeycomb-opentelemetry-ruby/blob/main/CHANGELOG.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/honeycomb-opentelemetry.gemspec
+++ b/honeycomb-opentelemetry.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"

--- a/honeycomb-opentelemetry.gemspec
+++ b/honeycomb-opentelemetry.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/honeycomb/opentelemetry/version"
 
 Gem::Specification.new do |spec|

--- a/lib/honeycomb/opentelemetry.rb
+++ b/lib/honeycomb/opentelemetry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "honeycomb/opentelemetry/version"
 require "honeycomb/opentelemetry/trace/baggage_span_processor"
 

--- a/lib/honeycomb/opentelemetry/trace/baggage_span_processor.rb
+++ b/lib/honeycomb/opentelemetry/trace/baggage_span_processor.rb
@@ -52,20 +52,23 @@ module Honeycomb
         # @param [Span] span the {Span} that just ended.
         def on_finish(span); end
 
-        # Export all ended spans to the configured `Exporter` that have not yet
-        # been exported.
+        # Export all ended spans to the configured `Exporter` that have not yet been exported.
+        # NO-OP method to satisfy the SpanProcessor duck type.
+        # Always successful; this processor does not maintain any state to flush.
         #
-        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @param [optional Numeric] timeout An optional timeout in seconds, unused in this implementation.
         # @return [Integer] 0 for success and there is nothing to flush so always successful.
-        def force_flush(timeout: nil)
+        def force_flush(_timeout: nil)
           0
         end
 
         # Called when {TracerProvider#shutdown} is called.
+        # NO-OP method to satisfy the SpanProcessor duck type.
+        # Always successful; this processor does not maintain any state to clean up or processes to close on shutdown.
         #
-        # @param [optional Numeric] timeout An optional timeout in seconds.
+        # @param [optional Numeric] timeout An optional timeout in seconds, unused in this implementation.
         # @return [Integer] 0 for success and there is nothing to stop so always successful.
-        def shutdown(timeout: nil)
+        def shutdown(_timeout: nil)
           0
         end
       end

--- a/lib/honeycomb/opentelemetry/trace/baggage_span_processor.rb
+++ b/lib/honeycomb/opentelemetry/trace/baggage_span_processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "opentelemetry" # API for Baggage access
 
 module Honeycomb

--- a/lib/honeycomb/opentelemetry/trace/baggage_span_processor.rb
+++ b/lib/honeycomb/opentelemetry/trace/baggage_span_processor.rb
@@ -5,40 +5,39 @@ require "opentelemetry" # API for Baggage access
 module Honeycomb
   module OpenTelemetry
     module Trace
+      # The BaggageSpanProcessor reads key/values stored in Baggage in the
+      # starting span's parent context and adds them as attributes to the span.
+      #
+      # Keys and values added to Baggage will appear on all subsequent child spans
+      # for a trace within this service *and* will be propagated to external services
+      # via propagation headers. If the external services also have a Baggage span
+      # processor, the keys and values will appear in those child spans as well.
+      #
+      # ⚠ ⚠ ⚠️
+      # To repeat: a consequence of adding data to Baggage is that the keys and
+      # values will appear in all outgoing HTTP headers from the application.
+      # Do not put sensitive information in Baggage.
+      # ⚠ ⚠ ⚠️
+      #
+      # @example
+      #   OpenTelemetry::SDK.configure do |c|
+      #     # Add the BaggageSpanProcessor to the collection of span processors
+      #     c.add_span_processor(Honeycomb::OpenTelemetry::Trace::BaggageSpanProcessor.new)
+      #
+      #     # Because the span processor list is no longer empty, the SDK will not use the
+      #     # values in OTEL_TRACES_EXPORTER to instantiate exporters.
+      #     # You'll need to declare your own here in the configure block.
+      #     #
+      #     # These lines setup the default: a batching OTLP exporter.
+      #     c.add_span_processor(
+      #       # these constructors without arguments will pull config from the environment
+      #       OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
+      #         OpenTelemetry::Exporter::OTLP::Exporter.new()
+      #       )
+      #     )
+      #   end
       class BaggageSpanProcessor
-        # Called when a {Span} is started, if the {Span#recording?} returns true.
-        #
-        # The BaggageSpanProcessor reads key/values stored in Baggage in the
-        # starting span's parent context and adds them as attributes to the span.
-        #
-        # Keys and values added to Baggage will appear on all subsequent child spans
-        # for a trace within this service *and* will be propagated to external services
-        # via propagation headers. If the external services also have a Baggage span
-        # processor, the keys and values will appear in those child spans as well.
-        #
-        # ⚠ ⚠ ⚠️
-        # To repeat: a consequence of adding data to Baggage is that the keys and
-        # values will appear in all outgoing HTTP headers from the application.
-        # Do not put sensitive information in Baggage.
-        # ⚠ ⚠ ⚠️
-        #
-        # @example
-        #   OpenTelemetry::SDK.configure do |c|
-        #     # Add the BaggageSpanProcessor to the collection of span processors
-        #     c.add_span_processor(Honeycomb::OpenTelemetry::Trace::BaggageSpanProcessor.new)
-        #
-        #     # Because the span processor list is no longer empty, the SDK will not use the
-        #     # values in OTEL_TRACES_EXPORTER to instantiate exporters.
-        #     # You'll need to declare your own here in the configure block.
-        #     #
-        #     # These lines setup the default: a batching OTLP exporter.
-        #     c.add_span_processor(
-        #       # these constructors without arguments will pull config from the environment
-        #       OpenTelemetry::SDK::Trace::Export::BatchSpanProcessor.new(
-        #         OpenTelemetry::Exporter::OTLP::Exporter.new()
-        #       )
-        #     )
-        #   end
+        # Called when a {Span} is started, adds Baggage keys/values to the span as attributes.
         #
         # @param [Span] span the {Span} that just started, expected to conform
         #  to the concrete {Span} interface from the SDK and respond to :add_attributes.

--- a/lib/honeycomb/opentelemetry/trace/baggage_span_processor.rb
+++ b/lib/honeycomb/opentelemetry/trace/baggage_span_processor.rb
@@ -44,6 +44,7 @@ module Honeycomb
         #  started span.
         def on_start(span, parent_context)
           return unless span.respond_to?(:add_attributes) && parent_context.is_a?(::OpenTelemetry::Context)
+
           span.add_attributes(::OpenTelemetry::Baggage.values(context: parent_context))
         end
 

--- a/lib/honeycomb/opentelemetry/version.rb
+++ b/lib/honeycomb/opentelemetry/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Honeycomb
   module OpenTelemetry
     VERSION = "0.1.0"

--- a/spec/honeycomb/opentelemetry_spec.rb
+++ b/spec/honeycomb/opentelemetry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Honeycomb::OpenTelemetry do
   it "has a version number" do
     expect(Honeycomb::OpenTelemetry::VERSION).not_to be nil

--- a/spec/honeycomb/trace/baggage_span_processor_spec.rb
+++ b/spec/honeycomb/trace/baggage_span_processor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "opentelemetry"     # API for Baggage access, Span interface for spy
 require "opentelemetry/sdk" # SDK in tests to assert Export::SUCCESS
 

--- a/spec/honeycomb/trace/baggage_span_processor_spec.rb
+++ b/spec/honeycomb/trace/baggage_span_processor_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe Honeycomb::OpenTelemetry::Trace::BaggageSpanProcessor do
     end
 
     it "implements #force_flush" do
-      expect(processor.force_flush).to eq(::OpenTelemetry::SDK::Trace::Export::SUCCESS)
+      expect(processor.force_flush).to eq(OpenTelemetry::SDK::Trace::Export::SUCCESS)
     end
 
     it "implements #shutdown" do
-      expect(processor.shutdown).to eq(::OpenTelemetry::SDK::Trace::Export::SUCCESS)
+      expect(processor.shutdown).to eq(OpenTelemetry::SDK::Trace::Export::SUCCESS)
     end
   end
 end

--- a/spec/honeycomb/trace/baggage_span_processor_spec.rb
+++ b/spec/honeycomb/trace/baggage_span_processor_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Honeycomb::OpenTelemetry::Trace::BaggageSpanProcessor do
 
     it "adds current baggage keys/values as attributes when a span starts" do
       processor.on_start(span, context_with_baggage)
-      expect(span).to have_received(:add_attributes).with({"a_key" => "a_value"})
+      expect(span).to have_received(:add_attributes).with({ "a_key" => "a_value" })
     end
 
     it "does not blow up when given nil context" do
@@ -28,7 +28,6 @@ RSpec.describe Honeycomb::OpenTelemetry::Trace::BaggageSpanProcessor do
     it "does not blow up when given a span that is not a Span" do
       expect { processor.on_start(:not_a_span, context_with_baggage) }.not_to raise_error
     end
-
   end
 
   describe "satisfy the SpanProcessor duck type with no-op methods" do
@@ -44,5 +43,4 @@ RSpec.describe Honeycomb::OpenTelemetry::Trace::BaggageSpanProcessor do
       expect(processor.shutdown).to eq(::OpenTelemetry::SDK::Trace::Export::SUCCESS)
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require "honeycomb/opentelemetry"
 


### PR DESCRIPTION
Adds Rubocop to the project and then addresses its findings.

While this is a big diff, if you walk the commits, each has a message about a distinct lint/format/style change that was made. 